### PR TITLE
docs: add PyPI and Python version badges (release pipeline test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # databrowser
 
+[![PyPI version](https://img.shields.io/pypi/v/databrowser.svg)](https://pypi.org/project/databrowser/)
+[![Python versions](https://img.shields.io/pypi/pyversions/databrowser.svg)](https://pypi.org/project/databrowser/)
+
 A terminal file browser for quickly viewing data files, from local disk or S3.
 
 Supports csv, parquet, json, xlsx, xls, xml and html — read into pandas DataFrames


### PR DESCRIPTION
Adds PyPI version + Python version badges to the README.

Doubles as the first live exercise of the new unified release pipeline (#174): merging this should auto bump-tag → build → publish to PyPI → create the GitHub release, in one workflow run.