### PR TITLE
feat: support feather, orc and tsv files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Overview
 
 `databrowser` is a terminal UI (TUI) application for browsing and viewing data files
-(csv, parquet, json, xlsx, xml, html) from local disk or S3. It is built on
+(csv, tsv, parquet, feather, orc, json, xlsx, xls, xml, html) from local disk or S3. It is built on
 [Textual](https://textual.textualize.io/) and reads files into pandas DataFrames.
 Originally derived from Textual's `code_browser` example.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A terminal file browser for quickly viewing data files, from local disk or S3.
 
-Supports csv, parquet, json, xlsx, xls, xml and html — read into pandas DataFrames
+Supports csv, tsv, parquet, feather, orc, json, xlsx, xls, xml and html — read into pandas DataFrames
 and shown in a scrollable table (with a dtype view). Built on
 [Textual](https://textual.textualize.io/).
 

--- a/src/databrowser/data_browser.py
+++ b/src/databrowser/data_browser.py
@@ -35,7 +35,10 @@ class DataBrowser(App):  # pylint: disable=too-many-instance-attributes
 
     LOADERS = {
         ".csv": pd.read_csv,
+        ".tsv": pd.read_table,  # tab-separated
         ".parquet": pd.read_parquet,
+        ".feather": pd.read_feather,
+        ".orc": pd.read_orc,
         ".json": pd.read_json,
         ".xlsx": pd.read_excel,
         ".xls": pd.read_excel,
@@ -48,7 +51,7 @@ class DataBrowser(App):  # pylint: disable=too-many-instance-attributes
     ROW_LIMIT = 100
     # Loaders whose pandas reader accepts ``nrows`` so we can avoid reading a whole
     # multi-GB file just to preview the first rows.
-    NROWS_LOADERS = {".csv", ".xlsx"}
+    NROWS_LOADERS = {".csv", ".tsv", ".xlsx"}
 
     show_tree = var(True)
     show_dtype = var(False)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -20,6 +20,9 @@ def data_dir(tmp_path):
     df.to_csv(tmp_path / "sample.csv", index=False)
     df.to_json(tmp_path / "sample.json")
     df.to_parquet(tmp_path / "sample.parquet")
+    df.to_feather(tmp_path / "sample.feather")
+    df.to_orc(tmp_path / "sample.orc")
+    df.to_csv(tmp_path / "sample.tsv", sep="\t", index=False)
     df.to_excel(tmp_path / "sample.xlsx", index=False)
     (tmp_path / "sample.html").write_text(df.to_html(index=False))
     # A frame larger than ROW_LIMIT to exercise truncation reporting.
@@ -48,7 +51,19 @@ async def test_tree_loads_supported_files(data_dir):
         assert "sample.json" in labels
 
 
-@pytest.mark.parametrize("filename", ["sample.csv", "sample.parquet", "sample.json", "sample.xlsx", "sample.html"])
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "sample.csv",
+        "sample.tsv",
+        "sample.parquet",
+        "sample.feather",
+        "sample.orc",
+        "sample.json",
+        "sample.xlsx",
+        "sample.html",
+    ],
+)
 async def test_selecting_file_populates_table(data_dir, filename):
     """Selecting a data file loads it into the DataTable with rows and columns."""
     app = DataBrowser(str(data_dir))


### PR DESCRIPTION
Adds three new formats to the `LOADERS` map — no new dependencies (pyarrow is already a dep):

- **`.feather`** → `pd.read_feather`
- **`.orc`** → `pd.read_orc`
- **`.tsv`** → `pd.read_table` (tab-separated; nrows-capped like csv)

Tests extended to load all three (14 tests pass), README/CLAUDE format lists updated. pylint 10/10.